### PR TITLE
security: add permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   org-guard:
     name: Verify Repository Organization

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 7 * * *'   # Daily at 07:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   org-guard:
     name: Verify Repository Organization

--- a/.github/workflows/encryption-enforcement.yml
+++ b/.github/workflows/encryption-enforcement.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   encryption-tests:
     name: Encryption & Security Tests

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   pii-scan:
     name: Scan for PII and secrets

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 6 * * *'   # Daily at 06:00 UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   org-guard:
     name: Verify Repository Organization

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   org-guard:
     name: Verify Repository Organization

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -19,6 +19,8 @@ on:
 
 permissions:
   contents: read
+  issues: read
+  pull-requests: read
 
 jobs:
   # ── 1:1 minimum — every PR/push must reference an issue ──────────────

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -17,6 +17,9 @@ on:
         description: 'Flag issues with no linked commit after N days'
         default: '7'
 
+permissions:
+  contents: read
+
 jobs:
   # ── 1:1 minimum — every PR/push must reference an issue ──────────────
   commit-references-issue:


### PR DESCRIPTION
## Summary
- Add explicit `permissions:` blocks to 7 workflow files missing them
- Follows principle of least privilege — each workflow gets only the permissions it needs
- Resolves GitHub Code Security "Workflow does not contain permissions" alerts

## Changes
- `ci.yml`, `daily.yml`, `encryption-enforcement.yml`, `pii-scan.yml`, `security-review.yml`, `security.yml`: `contents: read`
- `traceability.yml`: `contents: read` + `issues: read` + `pull-requests: read` (uses `gh issue list` and `gh pr list`)

## Test plan
- [ ] CI passes on this PR
- [ ] No permission denied errors in workflow runs

Generated with Claude Code