### PR TITLE
ci: SHA-pin all action refs (unblocks 47 days of dead CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -59,7 +59,7 @@ jobs:
           Write-Host "Strong names verified: PublicKeyToken=$ct"
 
       - name: Upload MSI installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: Parcl-Installer
           path: src/Parcl.Installer/bin/Release/Parcl.Installer.msi
@@ -69,10 +69,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -42,7 +42,7 @@ jobs:
         run: dotnet test tests/Parcl.Core.Tests/Parcl.Core.Tests.csproj --configuration Release --no-restore --verbosity normal
 
       - name: Upload MSI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: Parcl-daily-msi
           path: src/Parcl.Installer/bin/Release/Parcl.Installer.msi

--- a/.github/workflows/encryption-enforcement.yml
+++ b/.github/workflows/encryption-enforcement.yml
@@ -11,10 +11,10 @@ jobs:
     name: Encryption & Security Tests
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -32,7 +32,7 @@ jobs:
     name: SendDecision Coverage Audit
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Verify SendDecision is used in ItemSend
         shell: bash
@@ -102,10 +102,10 @@ jobs:
     name: Settings Default Regression Check
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,16 +24,16 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/pii-scan.yml
+++ b/.github/workflows/pii-scan.yml
@@ -11,7 +11,7 @@ jobs:
     name: Scan for PII and secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Scan for email addresses in source code
         run: |

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 
@@ -95,10 +95,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -56,10 +56,10 @@ jobs:
     runs-on: windows-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '8.0.x'
 
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: org-guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -24,7 +24,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## What

Pins all 30 action references across 8 workflows to commit SHAs.

## Why

The org sets `sha_pinning_required: true`. Every workflow here referenced actions by floating tag, so GitHub Actions rejected every run **at dispatch** — `startup_failure`, no job ever executed.

Observed: **30/30 runs blocked, 100% failure rate since 2026-06-21 (47 days).** Nothing in this repo has built or tested in seven weeks.

## Risk

Low. Each tag is pinned to the commit it currently resolves to, so behavior is unchanged — only the reference form differs. The original tag is kept as a trailing comment for readability.

## Verification

This PR triggers `ci.yml` on `pull_request`. If the diagnosis is right, CI runs for the first time since June. That result is the test.

Generated with Claude Code